### PR TITLE
Fixed bug due to directory and deprecated issues

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -74,7 +74,7 @@ for epoch in range(1,2):
         clothes = data['clothes']
         ##edge is extracted from the clothes image with the built-in function in python
         edge = data['edge']
-        edge = torch.FloatTensor((edge.detach().numpy() > 0.5).astype(np.int))
+        edge = torch.FloatTensor((edge.detach().numpy() > 0.5).astype(np.int64))
         clothes = clothes * edge        
 
         #import ipdb; ipdb.set_trace()
@@ -107,7 +107,7 @@ for epoch in range(1,2):
                 os.path.join('./our_t_results', data['p_name'][0]),
                 nrow=int(1),
                 normalize=True,
-                range=(-1,1),
+                value_range=(-1,1),
             )
             
             ## save person image, garment, flow, warped garment, and try-on image

--- a/test/test.py
+++ b/test/test.py
@@ -60,6 +60,8 @@ total_steps = (start_epoch-1) * dataset_size + epoch_iter
 step = 0
 step_per_batch = dataset_size / opt.batchSize
 
+if not os.path.exists('our_t_results'):
+  os.mkdir('our_t_results')
 
 for epoch in range(1,2):
 


### PR DESCRIPTION
The error shown below while running test.py due to the absence of our_t_results directory has been fixed.
```FileNotFoundError: [Errno 2] No such file or directory: './our_t_results/000001_0.jpg```

Also fixed deprecated issues.